### PR TITLE
Fix ssh in security group

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,11 @@ If you have multiple AWS account you can add multiple named sections to this fil
     $ git clone git@github.com:ngzax/urbit-devops.git
     $ cd urbit-devops/terraform
 
-
 ### Step 7: Create a terraform.tfvars file in the terraform directory
 
 This is the file that contains the specific information about your Amazon
 account and credentials and where they exist on your local computer. At minimum,
 the file needs to contain 3 lines that should look something like this:
-
 
     $ cat terraform.tfvars
     PATH_TO_PRIVATE_KEY     = "~/.ssh/ansible-key-pair-ohio.pem"
@@ -116,9 +114,15 @@ The name is just its name and the shared credentials is what you created in step
 If you have more than one Amazon account profile in your ~/.aws/credentials file
 you can select the one you want to use by adding it to terraform.tfvars:
 
-
     PROFILE                 = "ansible"
 
+Another important variable that you probably want to override is the
+ALLOW_SSH_FROM_IPS. This variable controls what ip addresses (or ranges) are
+allowed to access your urbit server via ssh. You will want to determine your
+local ip address and make sure to put that in there instead of the default which
+allows all addresses.
+
+[Click here for Amazon's documentation about security groups.](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html)
 
 ### Step 8: Install and Run Terraform
 

--- a/terraform/urbit-pier.tf
+++ b/terraform/urbit-pier.tf
@@ -12,7 +12,7 @@ resource "aws_security_group" "urbit-sg" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["158.81.208.0/24", "71.225.91.254/32"]
+    cidr_blocks = "${var.ALLOW_SSH_FROM_IPS}"
   }
 
   ingress {

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -1,9 +1,22 @@
+# ---
 # These variable MUST be set in your terraform.tfvars file
+# ---
 variable "PATH_TO_PRIVATE_KEY" { }
 variable "PRIVATE_KEY_NAME" { }
 variable "SHARED_CREDENTIALS_FILE" { }
 
+# ---
 # These variable can be optionally overridden in your terraform.tfvars file
+# ---
+variable "ALLOW_SSH_FROM_IPS" {
+  type = "list"
+  default = ["0.0.0.0/0", "0.0.0.0/0"]
+}
+
+variable "ALLOW_SSH_FROM_IP_2" {
+  default = "0.0.0.0/0"
+}
+
 variable "AWS_AMI_ID" {
   default = "ami-8a7859ef"
 }


### PR DESCRIPTION
I blew this on the initial creation. The allowable ssh ip addresses should not be hardcoded.